### PR TITLE
[AMQ-9107] Remove consumers more efficiently in ManagedRegionBroker

### DIFF
--- a/activemq-unit-tests/src/test/java/org/apache/activemq/broker/jmx/JMXRemoveOfflineDurableSubscriberTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/broker/jmx/JMXRemoveOfflineDurableSubscriberTest.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.broker.jmx;
+
+import org.apache.activemq.broker.BrokerService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class JMXRemoveOfflineDurableSubscriberTest {
+
+    private BrokerService broker;
+
+    private static final String SUBSCRIBER_NAME = "testSubscriber";
+    private static final String OFFLINE_CONNECTION_ID = "OFFLINE";
+    private static final String TOPIC_NAME = "testTopic";
+
+    @Before
+    public void setUp() throws Exception {
+        broker = new BrokerService();
+        broker.setBrokerName("ActiveMQBroker");
+        broker.setPersistent(false);
+        broker.setUseVirtualTopics(false);
+        broker.setUseJmx(true);
+        broker.addConnector("tcp://localhost:0");
+        broker.start();
+    }
+
+    @After
+    public void teardown() throws Exception {
+        broker.stop();
+        broker.waitUntilStopped();
+    }
+
+    @Test()
+    public void testCreateOfflineDurableSubscriber() throws Exception {
+        broker.getAdminView().addTopic(TOPIC_NAME);
+        broker.getAdminView().createDurableSubscriber(OFFLINE_CONNECTION_ID, SUBSCRIBER_NAME, TOPIC_NAME, null);
+        broker.getAdminView().destroyDurableSubscriber(OFFLINE_CONNECTION_ID, SUBSCRIBER_NAME);
+
+        // Just to make sure the subscriber was actually deleted, try deleting
+        // the offline subscriber again and that should throw an exception
+        boolean subscriberAlreadyDeleted = false;
+        try {
+            broker.getAdminView().destroyDurableSubscriber(OFFLINE_CONNECTION_ID, SUBSCRIBER_NAME);
+        } catch (javax.jms.InvalidDestinationException t) {
+            if (t.getMessage().equals("No durable subscription exists for clientID: " +
+                    OFFLINE_CONNECTION_ID + " and subscriptionName: " +
+                    SUBSCRIBER_NAME)) {
+                subscriberAlreadyDeleted = true;
+            }
+        }
+        assertTrue(subscriberAlreadyDeleted);
+    }
+}


### PR DESCRIPTION
Running a profiler while executing the sample code attached to [AMQ-9107](https://issues.apache.org/jira/browse/AMQ-9107) identified ManagedRegionBroker.removeConsumer as the bottleneck. The existing implementation loops over all the subscriptions to find the subscription for the consumer we want to close. When we have n consumers and we want to close them all this for loop is O(n^2) and when n is big enough it creates a serious performance issue. With 188,000 consumers we observe the CPU at 100% for ~40 minutes while all the connections are closed: 

<img width="1217" alt="image" src="https://user-images.githubusercontent.com/7095337/195011857-a6971abb-b73c-41fd-bd88-9ab376388949.png">


After this PR, running the same test case we observe a spike in CPU of only one minute or less, similar to what it took to create the consumers: 

<img width="968" alt="image" src="https://user-images.githubusercontent.com/7095337/195017869-c17c8b4a-fabc-4c2c-a909-6073955613a1.png">

I ran the full suite of tests and everything is passing.

